### PR TITLE
Add simple High & Low CLI game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # hello-world
-Just another repository
-some additional messages.
+
+簡単なハイアンドロー（High & Low）ゲームを追加しました。
+
+## 遊び方
+
+```bash
+python3 high_low.py
+```
+
+- 1〜100の数字を予想して入力
+- 「もっと大きい/小さい」のヒントで絞り込む
+- 当たったら回数が表示されます

--- a/high_low.py
+++ b/high_low.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Simple High & Low guessing game."""
+
+from __future__ import annotations
+
+import random
+
+
+def ask_int(prompt: str) -> int:
+    """Ask for an integer until valid input is provided."""
+    while True:
+        value = input(prompt).strip()
+        if value.lstrip("-").isdigit():
+            return int(value)
+        print("数字を入力してね！")
+
+
+def play_round() -> None:
+    """Play one round of high and low."""
+    answer = random.randint(1, 100)
+    attempts = 0
+
+    print("\n=== High & Low ===")
+    print("1〜100の数字を当ててね。")
+
+    while True:
+        guess = ask_int("予想の数字: ")
+        attempts += 1
+
+        if guess < answer:
+            print("もっと大きい！")
+        elif guess > answer:
+            print("もっと小さい！")
+        else:
+            print(f"正解！ {attempts}回で当たった！")
+            break
+
+
+def main() -> None:
+    print("ハイアンドローへようこそ！")
+    while True:
+        play_round()
+        again = input("もう1回やる？ (y/n): ").strip().lower()
+        if again not in {"y", "yes"}:
+            print("遊んでくれてありがとう！")
+            break
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Add a small interactive example to the repository so users can run a simple playable CLI demo.

### Description
- Add `high_low.py`, a CLI High & Low (1–100) number guessing game with input validation and attempt counting.
- Update `README.md` with run instructions using `python3 high_low.py` and a short gameplay overview.

### Testing
- Ran a syntax check with `python3 -m py_compile high_low.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfb048bc8832b94ab8705c02c45f1)